### PR TITLE
Fixes bug described in Issue #3

### DIFF
--- a/WebApp-B2C-DotNet/App_Start/Startup.Auth.cs
+++ b/WebApp-B2C-DotNet/App_Start/Startup.Auth.cs
@@ -64,10 +64,10 @@ namespace WebApp_OpenIDConnect_DotNet_B2C
                     String.Format(CultureInfo.InvariantCulture, aadInstance, tenant, "/v2.0", OIDCMetadataSuffix),
                     new string[] { SignUpPolicyId, SignInPolicyId, ProfilePolicyId }),
 
-                // This piece is optional - it is used for displaying the user's name in the navigation bar.
                 TokenValidationParameters = new TokenValidationParameters
                 {  
-                    NameClaimType = "name",
+                    NameClaimType = "name", // This piece is optional - it is used for displaying the user's name in the navigation bar.
+                    ValidateIssuer = false
                 },
             };
 

--- a/WebApp-B2C-DotNet/App_Start/Startup.Auth.cs
+++ b/WebApp-B2C-DotNet/App_Start/Startup.Auth.cs
@@ -64,10 +64,10 @@ namespace WebApp_OpenIDConnect_DotNet_B2C
                     String.Format(CultureInfo.InvariantCulture, aadInstance, tenant, "/v2.0", OIDCMetadataSuffix),
                     new string[] { SignUpPolicyId, SignInPolicyId, ProfilePolicyId }),
 
+                // This piece is optional - it is used for displaying the user's name in the navigation bar.
                 TokenValidationParameters = new TokenValidationParameters
-                {  
-                    NameClaimType = "name", // This piece is optional - it is used for displaying the user's name in the navigation bar.
-                    ValidateIssuer = false
+                {
+                    NameClaimType = "name",
                 },
             };
 

--- a/WebApp-B2C-DotNet/PolicyAuthHelpers/PolicyConfigurationManager.cs
+++ b/WebApp-B2C-DotNet/PolicyAuthHelpers/PolicyConfigurationManager.cs
@@ -97,29 +97,29 @@ namespace WebApp_OpenIDConnect_DotNet_B2C.Policies
             }
         }
 
-        // Takes the other and copies it to source, preserving the source's multi-valued attributes as a running sum.
+        // Takes the source and copies it to other, preserving the other's multi-valued attributes as a running sum.
         private OpenIdConnectConfiguration MergeConfig(OpenIdConnectConfiguration source, OpenIdConnectConfiguration other)
         {
-            ICollection<SecurityToken> existingSigningTokens = other.SigningTokens;
-            ICollection<string> existingAlgs = other.IdTokenSigningAlgValuesSupported;
-            ICollection<SecurityKey> existingSigningKeys = other.SigningKeys;
+            ICollection<SecurityToken> existingSigningTokens = source.SigningTokens;
+            ICollection<string> existingAlgs = source.IdTokenSigningAlgValuesSupported;
+            ICollection<SecurityKey> existingSigningKeys = source.SigningKeys;
 
             foreach (SecurityToken token in existingSigningTokens)
             {
-                source.SigningTokens.Add(token);
+                other.SigningTokens.Add(token);
             }
 
             foreach (string alg in existingAlgs)
             {
-                source.IdTokenSigningAlgValuesSupported.Add(alg);
+                other.IdTokenSigningAlgValuesSupported.Add(alg);
             }
 
             foreach (SecurityKey key in existingSigningKeys)
             {
-                source.SigningKeys.Add(key);
+                other.SigningKeys.Add(key);
             }
 
-            return source;
+            return other;
         }
 
         // This non-policy specific method effectively gets the metadata for all policies specified in the constructor,
@@ -133,7 +133,7 @@ namespace WebApp_OpenIDConnect_DotNet_B2C.Policies
             foreach (KeyValuePair<string, OpenIdConnectConfiguration> entry in clone)
             {
                 OpenIdConnectConfiguration config = await GetConfigurationByPolicyAsync(cancel, entry.Key);
-                configUnion = MergeConfig(configUnion, config);
+                configUnion = MergeConfig(config, configUnion);
             }
 
             return configUnion;

--- a/WebApp-B2C-DotNet/PolicyAuthHelpers/PolicyConfigurationManager.cs
+++ b/WebApp-B2C-DotNet/PolicyAuthHelpers/PolicyConfigurationManager.cs
@@ -97,29 +97,29 @@ namespace WebApp_OpenIDConnect_DotNet_B2C.Policies
             }
         }
 
-        // Takes the ohter and copies it to source, preserving the source's multi-valued attributes as a running sum.
+        // Takes the other and copies it to source, preserving the source's multi-valued attributes as a running sum.
         private OpenIdConnectConfiguration MergeConfig(OpenIdConnectConfiguration source, OpenIdConnectConfiguration other)
         {
-            ICollection<SecurityToken> existingSigningTokens = source.SigningTokens;
-            ICollection<string> existingAlgs = source.IdTokenSigningAlgValuesSupported;
-            ICollection<SecurityKey> existingSigningKeys = source.SigningKeys;
+            ICollection<SecurityToken> existingSigningTokens = other.SigningTokens;
+            ICollection<string> existingAlgs = other.IdTokenSigningAlgValuesSupported;
+            ICollection<SecurityKey> existingSigningKeys = other.SigningKeys;
 
             foreach (SecurityToken token in existingSigningTokens)
             {
-                other.SigningTokens.Add(token);
+                source.SigningTokens.Add(token);
             }
 
             foreach (string alg in existingAlgs)
             {
-                other.IdTokenSigningAlgValuesSupported.Add(alg);
+                source.IdTokenSigningAlgValuesSupported.Add(alg);
             }
 
             foreach (SecurityKey key in existingSigningKeys)
             {
-                other.SigningKeys.Add(key);
+                source.SigningKeys.Add(key);
             }
 
-            return other;
+            return source;
         }
 
         // This non-policy specific method effectively gets the metadata for all policies specified in the constructor,

--- a/WebApp-B2C-DotNet/PolicyAuthHelpers/PolicyConfigurationManager.cs
+++ b/WebApp-B2C-DotNet/PolicyAuthHelpers/PolicyConfigurationManager.cs
@@ -97,29 +97,41 @@ namespace WebApp_OpenIDConnect_DotNet_B2C.Policies
             }
         }
 
-        // Takes the source and copies it to other, preserving the other's multi-valued attributes as a running sum.
-        private OpenIdConnectConfiguration MergeConfig(OpenIdConnectConfiguration source, OpenIdConnectConfiguration other)
+        // Takes the other and copies it to source, preserving the source's multi-valued attributes as a running sum.
+        private OpenIdConnectConfiguration MergeConfig(OpenIdConnectConfiguration source, OpenIdConnectConfiguration other, bool collectionsOnly)
         {
-            ICollection<SecurityToken> existingSigningTokens = source.SigningTokens;
-            ICollection<string> existingAlgs = source.IdTokenSigningAlgValuesSupported;
-            ICollection<SecurityKey> existingSigningKeys = source.SigningKeys;
+            ICollection<SecurityToken> existingSigningTokens = other.SigningTokens;
+            ICollection<string> existingAlgs = other.IdTokenSigningAlgValuesSupported;
+            ICollection<SecurityKey> existingSigningKeys = other.SigningKeys;
 
             foreach (SecurityToken token in existingSigningTokens)
             {
-                other.SigningTokens.Add(token);
+                source.SigningTokens.Add(token);
             }
 
             foreach (string alg in existingAlgs)
             {
-                other.IdTokenSigningAlgValuesSupported.Add(alg);
+                source.IdTokenSigningAlgValuesSupported.Add(alg);
             }
 
             foreach (SecurityKey key in existingSigningKeys)
             {
-                other.SigningKeys.Add(key);
+                source.SigningKeys.Add(key);
             }
 
-            return other;
+            if (!collectionsOnly)
+            {
+                source.AuthorizationEndpoint = other.AuthorizationEndpoint;
+                source.CheckSessionIframe = other.CheckSessionIframe;
+                source.EndSessionEndpoint = other.EndSessionEndpoint;
+                source.Issuer = other.Issuer;
+                source.JwksUri = other.JwksUri;
+                source.TokenEndpoint = other.TokenEndpoint;
+                source.UserInfoEndpoint = other.UserInfoEndpoint;
+                source.JsonWebKeySet = other.JsonWebKeySet;
+            }
+
+            return source;
         }
 
         // This non-policy specific method effectively gets the metadata for all policies specified in the constructor,
@@ -130,10 +142,15 @@ namespace WebApp_OpenIDConnect_DotNet_B2C.Policies
         {
             OpenIdConnectConfiguration configUnion = new OpenIdConnectConfiguration();
             Dictionary<string, OpenIdConnectConfiguration> clone = new Dictionary<string, OpenIdConnectConfiguration>(_currentConfiguration);
+
+            int count = 0;
             foreach (KeyValuePair<string, OpenIdConnectConfiguration> entry in clone)
             {
                 OpenIdConnectConfiguration config = await GetConfigurationByPolicyAsync(cancel, entry.Key);
-                configUnion = MergeConfig(config, configUnion);
+
+                bool copyCollectionsOnly = (count > 0);
+                configUnion = MergeConfig(configUnion, config, copyCollectionsOnly);
+                count++;
             }
 
             return configUnion;


### PR DESCRIPTION
I've modified the `MergeConfig` method so that it now copies the collections from `other` into `source`.
I've also set `ValidateIssuer = false` on the `TokenValidationParameters` property of the `OpenIdConnectAuthenticationOptions` object inside the `ConfigureAuth` method of the `Startup` class. This will prevent the authentication from failing because the id_token issuer is not recognized (unless you specify the valid issuers on the TokenValidationParameters property).
